### PR TITLE
Add all extra

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,9 @@ test =
     pytest-astropy
 docs =
     sphinx-astropy
+all =
+    %(test)s
+    %(docs)s
 
 [options.package_data]
 gp_lts_workflow = data/*


### PR DESCRIPTION
So you can do `pip install package[all]` to get test and docs dependencies.